### PR TITLE
Minor improvements on the cookiecutter template

### DIFF
--- a/molecule_openstack/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_openstack/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -79,7 +79,7 @@
         floating_ip_pools: "{{ item.fip_pool | default(omit) }}"
         meta:
           ssh_user: "{{ item.ssh_user | default(ssh_user) }}"
-        register: server
+      register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200
       poll: 0
@@ -98,6 +98,7 @@
       set_fact:
         instance_conf_dict: {
           'instance': "{{ item.openstack.name }}",
+          'instance_id': "{{ item.openstack.id }}",
           'address': "{{ item.openstack.accessIPv4 }}",
           'user': "{{ item.openstack.metadata.ssh_user }}",
           'port': "{{ ssh_port }}",

--- a/molecule_openstack/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_openstack/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -27,9 +27,6 @@
 
     keypair_name: "keypair-{{ molecule_yml['platforms'][0]['name'] }}"
     keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
-
-    nova_image: Ubuntu-16.04
-    nova_flavor: NO-Nano
   tasks:
     - name: Create security group
       os_security_group:
@@ -71,10 +68,6 @@
         mode: 0600
       when: keypair.changed
 
-    - name: Gather facts about network for use with instance creation
-      os_networks_facts:
-        name: "{{ neutron_network_name }}"
-
     - name: Create molecule instance(s)
       os_server:
         name: "{{ item.name }}"
@@ -82,8 +75,8 @@
         flavor: "{{ item.flavor }}"
         security_groups: "{{ security_group_name }}"
         key_name: "{{ keypair_name }}"
-        nics:
-          - net-id: "{{ openstack_networks[0]['id'] }}"
+        network: "{{ item.network | default(neutron_network_name) }}"
+        floating_ip_pools: "{{ item.fip_pool | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/molecule_openstack/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
+++ b/molecule_openstack/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/create.yml
@@ -77,7 +77,9 @@
         key_name: "{{ keypair_name }}"
         network: "{{ item.network | default(neutron_network_name) }}"
         floating_ip_pools: "{{ item.fip_pool | default(omit) }}"
-      register: server
+        meta:
+          ssh_user: "{{ item.ssh_user | default(ssh_user) }}"
+        register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200
       poll: 0
@@ -97,7 +99,7 @@
         instance_conf_dict: {
           'instance': "{{ item.openstack.name }}",
           'address': "{{ item.openstack.accessIPv4 }}",
-          'user': "{{ ssh_user }}",
+          'user': "{{ item.openstack.metadata.ssh_user }}",
           'port': "{{ ssh_port }}",
           'identity_file': "{{ keypair_path }}", }
       with_items: "{{ os_jobs.results }}"

--- a/molecule_openstack/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule_openstack/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -8,11 +8,11 @@
   tasks:
     - name: Destroy molecule instance(s)
       os_server:
-        name: "{{ item.name }}"
+        name: "{{ item.instance_id }}"
         state: absent
         delete_fip: true
       register: server
-      with_items: "{{ molecule_yml.platforms }}"
+      with_items: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
       async: 7200
       poll: 0
 


### PR DESCRIPTION
Close #5 

This PR makes some minor improvements:
- User can now define a floating ip pool to use when this is required ( it is quite often in openstack cluster to not allow to directly hook-up to external networks but only with fips )
- Vm destruction is handled by using the instance_id. This allows multiple instances with the same name (2 developers testing at the same time, or cicd etc) 
- User can define a different network per instance (defaults to molecule which is defined in create.yml). 
- User can define a different ssh_user per instance (defaults to cloud-user which is defined in create.yml). E.g a user has 5 instances, 4 using ubuntu and 1 centos. User can define an ssh_user per instance or change the ssh_user of create.yml to ubuntu and only define the centos user for the 1 instance that is left.