### PR TITLE
Fix destroy when molecule_instance_config is missing

### DIFF
--- a/molecule_openstack/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule_openstack/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -6,13 +6,14 @@
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
   tasks:
+    # molecule_instance_config might not be present, therefore ignore errors and default to an empty config
     - name: Destroy molecule instance(s)
       os_server:
         name: "{{ item.instance_id }}"
         state: absent
         delete_fip: true
       register: server
-      loop: "{{ lookup('file', molecule_instance_config) | from_yaml | flatten(levels=1) }}"
+      loop: "{{ lookup('file', molecule_instance_config, errors='ignore') | default([], true) | from_yaml | flatten(levels=1) }}"
       async: 7200
       poll: 0
 


### PR DESCRIPTION
When molecule_instance_config is not there ignore errors and default to empty config

Wasn't able to catch this before as i was always testing with new role `foo` and the files is there...

Close #21 