### PR TITLE
feat: added other ansible_connection support

### DIFF
--- a/molecule_openstack/driver.py
+++ b/molecule_openstack/driver.py
@@ -119,7 +119,7 @@ class Openstack(Driver):
                 "ansible_host": d["address"],
                 "ansible_port": d["port"],
                 "connection": d.get("connection", "ssh"),
-                "ansible_connection": d.get("connection", "ssh")
+                "ansible_connection": d.get("connection", "ssh"),
             }
 
             if conn["connection"] == "ssh":
@@ -135,7 +135,7 @@ class Openstack(Driver):
             # Pass in extra {connection}_option keys to support other connection options
             # for example winrm_
             for key, val in d.items():
-                if conn['connection'] in key:
+                if conn["connection"] in key:
                     conn[key] = val
 
             return conn


### PR DESCRIPTION
Adding support for other connection types:

for example ansible_connection == "winrm"

I also had to remove the default connection = ssh so that other types can be passed through.

Support seems to be as simple as passing through values that match the pattern "ansible_winrm_*" or anything in your config that has the same name as the connection type _connectiontype_.

This seems to be working well for winrm in our test pipelines

Thanks