### PR TITLE
Remove support for python 3.6

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,10 +21,6 @@ jobs:
         include:
           - tox_env: lint
           # - tox_env: docs
-          - tox_env: py36
-            PREFIX: PYTEST_REQPASS=3
-          - tox_env: py36-devel
-            PREFIX: PYTEST_REQPASS=3
           - tox_env: py37
             PREFIX: PYTEST_REQPASS=3
           - tox_env: py38
@@ -36,12 +32,15 @@ jobs:
           - tox_env: packaging
 
     steps:
-      - uses: actions/checkout@v1
+      - name: Check out src from Git
+        uses: actions/checkout@v1
+
       - name: Install system dependencies
         run: |
           sudo apt-get update \
           && sudo apt-get install -y  ansible \
           && ansible-doc -l | grep os_keypair
+
       - name: Find python version
         id: py_ver
         shell: python
@@ -49,20 +48,24 @@ jobs:
         run: |
           v = '${{ matrix.tox_env }}'.split('-')[0].lstrip('py')
           print('::set-output name=version::{0}.{1}'.format(v[0],v[1:]))
+
       # Even our lint and other envs need access to tox
       - name: Install a default Python
         uses: actions/setup-python@v2
         if: ${{ ! contains(matrix.tox_env, 'py') }}
+
       # Be sure to install the version of python needed by a specific test, if necessary
       - name: Set up Python version
         uses: actions/setup-python@v2
         if: ${{ contains(matrix.tox_env, 'py') }}
         with:
           python-version: ${{ steps.py_ver.outputs.version }}
+
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           pip install tox
+
       - name: Run tox -e ${{ matrix.tox_env }}
         run: |
           echo "${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}"

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ cluster. They are not part of `ci` yet. To run them locally:
 
    $ source openstack_openrc.sh
 
-   $ tox -e py36-functional   # or 37,38,39
+   $ tox -e py37-functional   # or 38,39
 
 
 .. _get-involved:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 color_output = True
 error_summary = True
 disallow_untyped_calls=True

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -47,7 +46,7 @@ keywords =
 
 [options]
 use_scm_version = True
-python_requires = >=3.6
+python_requires = >=3.7
 packages = find:
 include_package_data = True
 zip_safe = False

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ minversion = 3.9.0
 envlist =
     lint
     packaging
-    py{36,37,38,39}
-    py{36,37,38,39}-{devel}
-    py{36,37,38,39}-functional
+    py{37,38,39}
+    py{37,38,39}-{devel}
+    py{37,38,39}-functional
 
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
@@ -21,8 +21,8 @@ download = true
 # sitepackages = True
 extras = test
 deps =
-    py{36,37,38,39}: molecule[test]
-    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
+    py{37,38,39}: molecule[test]
+    py{37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
 commands =
     pytest molecule_openstack/test/unit --collect-only
     pytest molecule_openstack/test/unit --color=yes {tty:-s}
@@ -50,7 +50,7 @@ whitelist_externals =
     pytest
     pre-commit
 
-[testenv:py{36,37,38,39}-functional]
+[testenv:py{37,38,39}-functional]
 description =
     Functional testing, require access to openstack cluster
 usedevelop = True


### PR DESCRIPTION
Since Python 3.6 is EOL since the end of 2021 we can safely drop support for it.