### PR TITLE
updating linting dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 ---
 repos:
   - repo: https://github.com/PyCQA/doc8.git
-    rev: 0.10.1
+    rev: 0.11.0
     hooks:
       - id: doc8
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:
       - id: isort
-  - repo: https://github.com/python/black.git
-    rev: 21.12b0
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -23,8 +23,8 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: debug-statements
-  - repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8.git
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies:
@@ -32,7 +32,6 @@ repos:
           - flake8-absolute-import
           - flake8-black>=0.1.1
           - flake8-docstrings>=1.5.0
-        language_version: python3
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.26.3
     hooks:
@@ -41,7 +40,7 @@ repos:
         types: [file, yaml]
         entry: yamllint --strict
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.920
+    rev: v0.942
     hooks:
       - id: mypy
         # empty args needed in order to match mypy cli behavior


### PR DESCRIPTION
updating linting dependencies

- bump doc8 to 0.11.0
- bump black to 22.3.0
- bump pre-commit-hooks to v4.1.0
- bump mirrors-mypy to v0.942
