### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,9 +21,9 @@ jobs:
         include:
           - tox_env: lint
           # - tox_env: docs
-          - tox_env: py37
-            PREFIX: PYTEST_REQPASS=3
           - tox_env: py38
+            PREFIX: PYTEST_REQPASS=3
+          - tox_env: py38-devel
             PREFIX: PYTEST_REQPASS=3
           - tox_env: py39
             PREFIX: PYTEST_REQPASS=3

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ cluster. They are not part of `ci` yet. To run them locally:
 
    $ source openstack_openrc.sh
 
-   $ tox -e py37-functional   # or 38,39
+   $ tox -e py38-functional   # or 39
 
 
 .. _get-involved:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 color_output = True
 error_summary = True
 disallow_untyped_calls=True

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 
@@ -46,7 +45,7 @@ keywords =
 
 [options]
 use_scm_version = True
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find:
 include_package_data = True
 zip_safe = False

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ minversion = 3.9.0
 envlist =
     lint
     packaging
-    py{37,38,39}
-    py{37,38,39}-{devel}
-    py{37,38,39}-functional
+    py{38,39}
+    py{38,39}-{devel}
+    py{38,39}-functional
 
 # do not enable skip missing to avoid CI false positives
 skip_missing_interpreters = False
@@ -21,8 +21,8 @@ download = true
 # sitepackages = True
 extras = test
 deps =
-    py{37,38,39}: molecule[test]
-    py{37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
+    py{38,39}: molecule[test]
+    py{38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
 commands =
     pytest molecule_openstack/test/unit --collect-only
     pytest molecule_openstack/test/unit --color=yes {tty:-s}
@@ -50,7 +50,7 @@ whitelist_externals =
     pytest
     pre-commit
 
-[testenv:py{37,38,39}-functional]
+[testenv:py{38,39}-functional]
 description =
     Functional testing, require access to openstack cluster
 usedevelop = True


### PR DESCRIPTION
Since ansible-core already removed support for Python 3.7 and the next version of Molecule is gonna drop it too.