### PR TITLE
use allowlist_externals instead of whitelist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ passenv =
     SSL_CERT_FILE
     TOXENV
     TWINE_*
-whitelist_externals =
+allowlist_externals =
     bash
     twine
     pytest
@@ -97,7 +97,7 @@ passenv =
     TWINE_*
     MOLECULE_*
     OS_*
-whitelist_externals =
+allowlist_externals =
     bash
     twine
     pytest


### PR DESCRIPTION
`whitelist_externals` is now deprecated, use `allowlist_externals` instead.

See: https://tox.wiki/en/latest/config.html#conf-allowlist_externals