### PR TITLE
Expose required collection

### DIFF
--- a/molecule_openstack/driver.py
+++ b/molecule_openstack/driver.py
@@ -18,6 +18,7 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 import os
+from typing import Dict
 
 from molecule.api import Driver
 
@@ -146,3 +147,8 @@ class Openstack(Driver):
         command in order to figure out where to load the templates from.
         """
         return os.path.join(os.path.dirname(__file__), "cookiecutter")
+
+    @property
+    def required_collections(self) -> Dict[str, str]:
+        """Return collections dict containing names and versions required."""
+        return {"openstack.cloud": "1.5.3"}

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,4 @@
+# helps ansible-lint install required collection when it is missing
+collections:
+  - name: openstack.cloud
+    version: ">=1.5.3"

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    molecule >= 3.2.0
+    molecule >= 3.4.0
     pyyaml >= 5.1, < 6
 
 [options.extras_require]


### PR DESCRIPTION
This lifts the minimum required molecule version to 3.4.0

Depends-On: ansible-community/molecule#3192